### PR TITLE
fix: deleteMessagesBySearch

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -481,7 +481,7 @@ export class MailpitClient {
     search: MailpitSearchDeleteRequest,
   ): Promise<string> {
     return this.handleRequest(() =>
-      this.axiosInstance.delete<string>(`/api/v1/search`, { data: search }),
+      this.axiosInstance.delete<string>(`/api/v1/search`, { params: search }),
     );
   }
 


### PR DESCRIPTION
Using deleteMessagesBySearch was causing error `Mailpit API Error: 400 Bad Request: "Error: no search query"` due to wrong params name.