### PR TITLE
Move documentation from the wiki to Pages

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -1,0 +1,47 @@
+name: Deploy TypeDoc to GitHub Pages
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Generate TypeDoc documentation
+        run: npm run docs
+
+      - name: Upload GitHub Pages artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: docs
+
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    permissions:
+      pages: write
+      id-token: write
+
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "mailpit-api",
-  "version": "1.4.0-alpha",
+  "version": "1.4.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "mailpit-api",
-      "version": "1.4.0-alpha",
+      "version": "1.4.0",
       "license": "MIT",
       "dependencies": {
         "axios": "^1.9.0"
@@ -20,8 +20,7 @@
         "tsup": "^8.5.0",
         "tsx": "^4.19.4",
         "typedoc": "^0.28.4",
-        "typedoc-github-wiki-theme": "^2.1.0",
-        "typedoc-plugin-markdown": "^4.6.3",
+        "typedoc-github-theme": "^0.3.0",
         "typescript": "^5.8.3",
         "typescript-eslint": "^8.32.1"
       }
@@ -6082,27 +6081,17 @@
         "typescript": "5.0.x || 5.1.x || 5.2.x || 5.3.x || 5.4.x || 5.5.x || 5.6.x || 5.7.x || 5.8.x"
       }
     },
-    "node_modules/typedoc-github-wiki-theme": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/typedoc-github-wiki-theme/-/typedoc-github-wiki-theme-2.1.0.tgz",
-      "integrity": "sha512-5j4vuoGwLn8PM1HeXocbwUF0Ra2qTFLeqsQwBQsLBPIx7Tl/lxkas1qIPFg/InOYwy9Y3Pn4xSjh+c/KM+jh6Q==",
-      "dev": true,
-      "license": "MIT",
-      "peerDependencies": {
-        "typedoc-plugin-markdown": ">=4.3.0"
-      }
-    },
-    "node_modules/typedoc-plugin-markdown": {
-      "version": "4.6.3",
-      "resolved": "https://registry.npmjs.org/typedoc-plugin-markdown/-/typedoc-plugin-markdown-4.6.3.tgz",
-      "integrity": "sha512-86oODyM2zajXwLs4Wok2mwVEfCwCnp756QyhLGX2IfsdRYr1DXLCgJgnLndaMUjJD7FBhnLk2okbNE9PdLxYRw==",
+    "node_modules/typedoc-github-theme": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/typedoc-github-theme/-/typedoc-github-theme-0.3.0.tgz",
+      "integrity": "sha512-7HzKJt8ZZSTNYczK8BcZZbpr7GsyTZgsoLFKtO4NYxXOb7mSr92yTj7hl16ind0WsOzxPo2DZGjkUH2VoPrdxg==",
       "dev": true,
       "license": "MIT",
       "engines": {
-        "node": ">= 18"
+        "node": ">=18.0.0"
       },
       "peerDependencies": {
-        "typedoc": "0.28.x"
+        "typedoc": "~0.28.0"
       }
     },
     "node_modules/typedoc/node_modules/brace-expansion": {

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "build": "tsup src/index.ts --dts --format esm,cjs --outDir dist",
     "pretty": "npx prettier . --write",
     "lint": "npx eslint --fix src",
-    "docs": "typedoc --readme none"
+    "docs": "typedoc"
   },
   "keywords": [
     "mailpit-api",
@@ -46,8 +46,7 @@
     "tsup": "^8.5.0",
     "tsx": "^4.19.4",
     "typedoc": "^0.28.4",
-    "typedoc-github-wiki-theme": "^2.1.0",
-    "typedoc-plugin-markdown": "^4.6.3",
+    "typedoc-github-theme": "^0.3.0",
     "typescript": "^5.8.3",
     "typescript-eslint": "^8.32.1"
   }

--- a/typedoc.json
+++ b/typedoc.json
@@ -1,11 +1,6 @@
 {
-  "plugin": ["typedoc-plugin-markdown", "typedoc-github-wiki-theme"],
+  "plugin": ["typedoc-github-theme"],
   "out": "./docs",
-  "indexFormat": "table",
-  "parametersFormat": "table",
-  "interfacePropertiesFormat": "table",
-  "classPropertiesFormat": "table",
-  "enumMembersFormat": "table",
-  "propertyMembersFormat": "table",
-  "typeDeclarationFormat": "table"
+  "entryPoints": ["./src/index.ts"],
+  "includeVersion": true
 }


### PR DESCRIPTION
- Move documenation to Pages instead of the wiki.
- Remove TypeDoc plugins related to wiki site generation
- Add pipeline to automatically publish the documentation to Pages