### PR TITLE
Add support for Mailpit v1.26.1 change

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,7 +12,7 @@ on:
   workflow_dispatch:
     inputs:
       username:
-        description: 'Username for Mailpit'
+        description: "Username for Mailpit"
         required: false
         type: string
   pull_request:

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Package Version](https://img.shields.io/npm/v/mailpit-api.svg?label=npm)](https://www.npmjs.com/package/mailpit-api)
 [![Test Suite](https://github.com/mpspahr/mailpit-api/actions/workflows/test.yml/badge.svg?branch=main)](https://github.com/mpspahr/mailpit-api/actions/workflows/npm-publish.yml)
-[![Code Coverage](https://codecov.io/gh/mpspahr/mailpit-api/branch/main/graph/badge.svg)](https://codecov.io/gh/mpspahr/mailpit-api)
+[![Code Coverage](https://codecov.io/gh/mpspahr/mailpit-api/graph/badge.svg?token=VUWKIYK1WM)](https://codecov.io/gh/mpspahr/mailpit-api)
 [![Documentation](https://github.com/mpspahr/mailpit-api/actions/workflows/deploy-docs.yml/badge.svg?branch=main&label=docs)](https://mpspahr.github.io/mailpit-api/)
 
 A TypeScript client for interacting with [Mailpit](https://mailpit.axllent.org/)'s [REST API](https://mailpit.axllent.org/docs/api-v1/view.html#get-/api/v1/info). Ideal for automating your email testing.

--- a/src/index.ts
+++ b/src/index.ts
@@ -131,6 +131,8 @@ export interface MailpitConfigurationResponse {
     Enabled: boolean;
     /** Overrides the "From" address for all relayed messages */
     OverrideFrom: string;
+    /** Preserve the original Message-IDs when relaying messages */
+    PreserveMessageIDs: boolean;
     /** @deprecated Refer to `AllowedRecipients` instead. No longer documented upstream */
     RecipientAllowlist: string;
     /** Enforced Return-Path (if set) for relay bounces */

--- a/tests/index.e2e.spec.ts
+++ b/tests/index.e2e.spec.ts
@@ -144,6 +144,7 @@ describe("MailpitClient E2E Tests", () => {
           BlockedRecipients: expect.any(String),
           Enabled: expect.any(Boolean),
           OverrideFrom: expect.any(String),
+          PreserveMessageIDs: expect.any(Boolean),
           RecipientAllowlist: expect.any(String), // deprecated but still returned
           ReturnPath: expect.any(String),
           SMTPServer: expect.any(String),


### PR DESCRIPTION
Add new `PreserveMessageIDs` key to `MailpitConfigurationResponse`