### PR TITLE
Do not report codecov for dependabot and define permissions

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -12,6 +12,9 @@ concurrency:
 
 jobs:
   call-tests:
+    permissions:
+      contents: read
+      pull-requests: read
     uses: ./.github/workflows/test.yml
     with:
       username: ${{ github.actor }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,5 +1,9 @@
 name: Test Suite
 
+permissions:
+  contents: read
+  pull-requests: read
+
 on:
   workflow_call:
     inputs:
@@ -53,7 +57,7 @@ jobs:
       - name: Run All Tests
         run: npm run test
       - name: Upload coverage to Codecov
-        if: github.event_name == 'pull_request' || github.ref == 'refs/heads/main'
+        if: (github.event_name == 'pull_request' && github.actor != 'dependabot[bot]') || github.ref == 'refs/heads/main'
         uses: codecov/codecov-action@v4
         with:
           token: ${{ secrets.CODECOV_TOKEN }}


### PR DESCRIPTION
- Change the Test Suite workflow so that it does not report code coverage for dependabot pull requests.
- Add permissions to the Test Suite workflow and it's call from the publish workflow.