### PR TITLE
Add CODEOWNERS file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,13 @@
+# Global owner
+*                       @mpspahr
+
+# Workflow files
+.github/workflows/*     @mpspahr
+
+# Package files
+package.json            @mpspahr
+package-lock.json       @mpspahr
+
+# Source code
+src/*                   @mpspahr
+tests/*                 @mpspahr

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,8 +5,6 @@ updates:
     schedule:
       interval: "weekly"
     open-pull-requests-limit: 5
-    reviewers:
-      - "mpspahr"
     assignees:
       - "mpspahr"
     labels:
@@ -23,8 +21,6 @@ updates:
     schedule:
       interval: "monthly"
     open-pull-requests-limit: 3
-    reviewers:
-      - "mpspahr"
     assignees:
       - "mpspahr"
     labels:

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -2,12 +2,12 @@
 
 ## Supported Versions
 
-Security updates and patches will be released for the latest major version of mailpit-api:
-
 | Version | Supported          |
 | ------- | ------------------ |
-| 1.5.x   | :white_check_mark: |
-| < 1.5.0 | :x:                |
+| Latest  | :white_check_mark: |
+| < Latest | :x:               |
+
+Only the latest release of mailpit-api receives security updates and patches.
 
 ## Reporting a Vulnerability
 


### PR DESCRIPTION
- Add CODEOWNERS file
- Remove deprecated reviewer keys from dependabot
- Tweak security policy to require less maintenance