### PR TITLE
chore(deps): widen axios version to 1.8.4+ and adjust dependabot configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,7 +5,7 @@ updates:
     schedule:
       interval: "weekly"
       day: "friday"
-      time: "20:00"
+      time: "21:00"
     open-pull-requests-limit: 5
     assignees:
       - "mpspahr"
@@ -13,17 +13,17 @@ updates:
       - "dependencies"
     commit-message:
       prefix: "chore(deps):"
+    versioning-strategy: widen
     groups:
-      npm-dependencies:
-        patterns:
-          - "*"
+      production:
+        dependency-type: "production"
 
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
       interval: "monthly"
       day: "friday"
-      time: "20:00"
+      time: "21:00"
     open-pull-requests-limit: 3
     assignees:
       - "mpspahr"

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.5.2",
       "license": "MIT",
       "dependencies": {
-        "axios": "^1.10.0"
+        "axios": "^1.8.4"
       },
       "devDependencies": {
         "@eslint/js": "^9.29.0",

--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
   "author": "Matthew Spahr",
   "license": "MIT",
   "dependencies": {
-    "axios": "^1.10.0"
+    "axios": "^1.8.4"
   },
   "devDependencies": {
     "@eslint/js": "^9.29.0",


### PR DESCRIPTION
* Change Axios dependency to support versions 1.8.4+
* Change Dependabot to no longer request non-security changes for development packages
* Change Dependabot to use a widen strategy on production packages
