### PR TITLE
fix(deps): update dependabot to fix production dependency allowance

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -14,9 +14,8 @@ updates:
     commit-message:
       prefix: "chore(deps):"
     versioning-strategy: widen
-    groups:
-      production:
-        dependency-type: "production"
+    allow:
+      - dependency-type: "production"
 
   - package-ecosystem: "github-actions"
     directory: "/"


### PR DESCRIPTION
Fix Dependabot configuration to only update production packages and remove unnecessary package grouping.