### PR TITLE
feat: add WebSocket support for real-time events

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,12 +9,15 @@
       "version": "1.5.4",
       "license": "MIT",
       "dependencies": {
-        "axios": "^1.12.1"
+        "axios": "^1.12.1",
+        "partysocket": "^1.0.2",
+        "ws": "^8.18.0"
       },
       "devDependencies": {
         "@eslint/js": "^9.35.0",
         "@jest/globals": "^30.1.2",
         "@types/node": "^22.18.3",
+        "@types/ws": "^8.5.13",
         "dotenv": "^17.2.2",
         "eslint": "^9.35.0",
         "eslint-plugin-jest": "^29.0.1",
@@ -1997,6 +2000,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/ws": {
+      "version": "8.18.1",
+      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.18.1.tgz",
+      "integrity": "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
     "node_modules/@types/yargs": {
       "version": "17.0.33",
       "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.33.tgz",
@@ -3627,6 +3640,12 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/event-target-polyfill": {
+      "version": "0.0.4",
+      "resolved": "https://registry.npmjs.org/event-target-polyfill/-/event-target-polyfill-0.0.4.tgz",
+      "integrity": "sha512-Gs6RLjzlLRdT8X9ZipJdIZI/Y6/HhRLyq9RdDlCsnpxr/+Nn6bU2EFGuC94GjxqhM+Nmij2Vcq98yoHrU8uNFQ==",
+      "license": "MIT"
     },
     "node_modules/execa": {
       "version": "5.1.1",
@@ -5634,6 +5653,15 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/partysocket": {
+      "version": "1.1.10",
+      "resolved": "https://registry.npmjs.org/partysocket/-/partysocket-1.1.10.tgz",
+      "integrity": "sha512-ACfn0P6lQuj8/AqB4L5ZDFcIEbpnIteNNObrlxqV1Ge80GTGhjuJ2sNKwNQlFzhGi4kI7fP/C1Eqh8TR78HjDQ==",
+      "license": "MIT",
+      "dependencies": {
+        "event-target-polyfill": "^0.0.4"
+      }
+    },
     "node_modules/path-exists": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
@@ -7084,6 +7112,27 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/ws": {
+      "version": "8.18.3",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.3.tgz",
+      "integrity": "sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
       }
     },
     "node_modules/y18n": {

--- a/package.json
+++ b/package.json
@@ -59,12 +59,15 @@
   "author": "Matthew Spahr",
   "license": "MIT",
   "dependencies": {
-    "axios": "^1.12.1"
+    "axios": "^1.12.1",
+    "partysocket": "^1.0.2",
+    "ws": "^8.18.0"
   },
   "devDependencies": {
     "@eslint/js": "^9.35.0",
     "@jest/globals": "^30.1.2",
     "@types/node": "^22.18.3",
+    "@types/ws": "^8.5.13",
     "dotenv": "^17.2.2",
     "eslint": "^9.35.0",
     "eslint-plugin-jest": "^29.0.1",

--- a/tests/index.spec.ts
+++ b/tests/index.spec.ts
@@ -7,6 +7,7 @@ import {
   test,
 } from "@jest/globals";
 import axios, { AxiosInstance } from "axios";
+import { WebSocket as ReconnectingWebSocket } from "partysocket";
 import { MailpitClient } from "../src/index";
 
 jest.mock("axios");
@@ -14,6 +15,28 @@ jest.mock("axios");
 describe("MailpitClient", () => {
   let client: MailpitClient;
   let mockedAxios: jest.Mocked<AxiosInstance>;
+  let internalClient: {
+    connectWebSocket: () => void;
+    disconnect: () => void;
+    webSocket: ReconnectingWebSocket | null;
+    onEvent: (
+      eventType: string,
+      listener: (event: unknown) => void,
+    ) => () => void;
+    waitForEvent: (
+      eventType: string,
+      timeout?: number,
+    ) => Promise<{ Type: string; Data: unknown }>;
+    eventListeners: Map<
+      string,
+      Set<(event: { Type: string; Data: unknown }) => void>
+    >;
+    handleWebSocketMessage: (message: { Type: string; Data: unknown }) => void;
+    removeListener: (
+      eventType: string,
+      listener: (event: unknown) => void,
+    ) => void;
+  };
 
   beforeEach(() => {
     mockedAxios = {
@@ -21,6 +44,7 @@ describe("MailpitClient", () => {
       post: jest.fn(),
       put: jest.fn(),
       delete: jest.fn(),
+      defaults: {},
     } as unknown as jest.Mocked<AxiosInstance>;
 
     // Mock axios.create to return our mocked instance
@@ -37,6 +61,7 @@ describe("MailpitClient", () => {
     });
 
     client = new MailpitClient("http://localhost:8025");
+    internalClient = client as unknown as typeof internalClient;
   });
 
   afterEach(() => {
@@ -138,5 +163,175 @@ describe("MailpitClient", () => {
     await expect(client.getInfo()).rejects.toThrow(
       /Mailpit API Error: .+ at UNKNOWN METHOD UNKNOWN URL/,
     );
+  });
+
+  // Constructor validation tests
+  test("should throw error for malformed protocol", () => {
+    expect(() => new MailpitClient("ht!tp://bad-url")).toThrow(
+      "The value of the 'baseURL' parameter must start with http:// or https://",
+    );
+  });
+
+  // WebSocket configuration tests (connection behavior is tested in E2E)
+  test("should not auto-connect WebSocket by default", () => {
+    const client = new MailpitClient("http://localhost:8025");
+    expect(client["webSocket"]).toBeNull();
+  });
+
+  test("connectWebSocket() should return early when already connected", () => {
+    const existingWebSocket = {
+      readyState: ReconnectingWebSocket.OPEN,
+    } as unknown as ReconnectingWebSocket;
+
+    internalClient.webSocket = existingWebSocket;
+
+    internalClient.connectWebSocket();
+
+    expect(internalClient.webSocket).toBe(existingWebSocket);
+  });
+
+  test("disconnect() should do nothing when no WebSocket exists", () => {
+    internalClient.webSocket = null;
+    internalClient.disconnect();
+
+    expect(internalClient.webSocket).toBeNull();
+  });
+
+  test("onEvent() should return unsubscribe function that removes listener", () => {
+    const listener1 = jest.fn();
+    const listener2 = jest.fn();
+
+    const unsubscribe1 = internalClient.onEvent("new", listener1);
+    const unsubscribe2 = internalClient.onEvent("new", listener2);
+
+    expect(internalClient.eventListeners.get("new")?.size).toBe(2);
+
+    unsubscribe1();
+    expect(internalClient.eventListeners.get("new")?.size).toBe(1);
+
+    unsubscribe2();
+    expect(internalClient.eventListeners.has("new")).toBe(false);
+  });
+
+  test("waitForEvent() should auto-connect when WebSocket is closed", () => {
+    const closedWebSocket = {
+      readyState: ReconnectingWebSocket.CLOSED,
+    } as unknown as ReconnectingWebSocket;
+
+    internalClient.webSocket = closedWebSocket;
+
+    const promise = internalClient.waitForEvent("new", 100);
+
+    expect(internalClient.webSocket).not.toBe(closedWebSocket);
+    expect(internalClient.webSocket).not.toBeNull();
+
+    // Clean up the promise to avoid unhandled rejection
+    promise.catch(() => {});
+  });
+
+  test("waitForEvent() should timeout and remove listener", async () => {
+    const promise = internalClient.waitForEvent("new", 50);
+
+    await expect(promise).rejects.toThrow(
+      'Timeout waiting for event of type "new"',
+    );
+
+    // Verify listener was cleaned up (Set should be empty)
+    const listeners = internalClient.eventListeners.get("new");
+    expect(listeners?.size || 0).toBe(0);
+  });
+
+  test("waitForEvent() should not timeout when passed Infinity", async () => {
+    // Spy on the method and wrap it to provide a short default timeout
+    const originalMethod = internalClient.waitForEvent.bind(internalClient);
+    const spy = jest.fn((eventType: string, timeout: number = 50) => {
+      return originalMethod(eventType, timeout);
+    });
+    internalClient.waitForEvent = spy;
+
+    // Pass Infinity explicitly - message arrives at 100ms
+    // The spy has a default timeout of 50ms, so if Infinity wasn't respected,
+    // this test would fail with a timeout error at 50ms before the message arrives at 100ms
+    const promise = internalClient.waitForEvent("new", Infinity);
+
+    // Verify the method was called with Infinity
+    expect(spy).toHaveBeenCalledWith("new", Infinity);
+
+    // Verify listener was added
+    const listeners = internalClient.eventListeners.get("new");
+    expect(listeners?.size).toBe(1);
+
+    // Simulate a message arriving after 100ms
+    // This is longer than the 50ms default - proves Infinity disabled the timeout
+    setTimeout(() => {
+      internalClient.handleWebSocketMessage({
+        Type: "new",
+        Data: { ID: "test-123" },
+      });
+    }, 100);
+
+    const result = await promise;
+
+    expect(result.Type).toBe("new");
+    expect(result.Data).toEqual({ ID: "test-123" });
+
+    // Verify listener was cleaned up after resolution
+    expect(internalClient.eventListeners.get("new")?.size || 0).toBe(0);
+  });
+
+  test("removeListener() should handle removeListener when no listeners exist", () => {
+    const removeListener = internalClient.removeListener.bind(internalClient);
+
+    // Call removeListener when there are no listeners registered
+    // This should not throw an error
+    expect(() => {
+      removeListener("new", () => {});
+    }).not.toThrow();
+  });
+
+  test("should silently ignore malformed JSON messages from WebSocket", () => {
+    let capturedMessageHandler: ((event: { data: string }) => void) | null =
+      null;
+
+    // Mock the WebSocket constructor to capture the message handler
+    const mockWebSocket = {
+      readyState: ReconnectingWebSocket.OPEN,
+      addEventListener: jest.fn(
+        (event: string, handler: (e: { data: string }) => void) => {
+          if (event === "message") {
+            capturedMessageHandler = handler;
+          }
+        },
+      ),
+      removeEventListener: jest.fn(),
+      close: jest.fn(),
+    };
+
+    // Mock the ReconnectingWebSocket constructor
+    const originalWebSocket = ReconnectingWebSocket;
+    (ReconnectingWebSocket as unknown as jest.Mock) = jest.fn(
+      () => mockWebSocket,
+    );
+
+    const mockListener = jest.fn();
+    client.onEvent("new", mockListener);
+
+    // Trigger WebSocket connection
+    internalClient.connectWebSocket();
+
+    // Verify the message handler was captured
+    expect(capturedMessageHandler).not.toBeNull();
+
+    // Call the handler with malformed JSON - this should not throw
+    expect(() => {
+      capturedMessageHandler?.({ data: "{ this is not valid json }" });
+    }).not.toThrow();
+
+    // Verify listener was never called (malformed message was silently ignored)
+    expect(mockListener).not.toHaveBeenCalled();
+
+    // Restore the original WebSocket
+    (ReconnectingWebSocket as unknown as typeof originalWebSocket) =
+      originalWebSocket;
   });
 });


### PR DESCRIPTION
Add real-time event streaming with onEvent() and waitForEvent() methods. 
Supports all Mailpit event types with automatic reconnection and authentication.