### PR TITLE
feat: add checksums to MailpitAttachmentResponse

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -47,6 +47,15 @@ export interface MailpitAttachmentResponse {
   PartID: string;
   /** Size in bytes */
   Size: number;
+  /** Checksums for the attachment */
+  Checksums: {
+    /** MD5 checksum */
+    MD5: string;
+    /** SHA1 checksum */
+    SHA1: string;
+    /** SHA256 checksum */
+    SHA256: string;
+  };
 }
 
 /** Represents information about a Chaos trigger */

--- a/tests/index.e2e.spec.ts
+++ b/tests/index.e2e.spec.ts
@@ -192,6 +192,11 @@ describe("MailpitClient E2E Tests", () => {
         FileName: expect.any(String),
         PartID: expect.any(String),
         Size: expect.any(Number),
+        Checksums: {
+          MD5: expect.any(String),
+          SHA1: expect.any(String),
+          SHA256: expect.any(String),
+        },
       };
       const expected = {
         Attachments: [expectedAttachment],


### PR DESCRIPTION
Adds Checksums key to MailpitAttachmentResponse interface to support Mailpit v1.29.0