### PR TITLE
fix: update MailpitSpamAssassinResponse to allow null rules on error

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -389,15 +389,20 @@ export interface MailpitSpamAssassinResponse {
   Error: string;
   /** Whether the message is spam or not */
   IsSpam: boolean;
-  /** Spam rules triggered */
-  Rules: {
-    /** SpamAssassin rule description */
-    Description: string;
-    /** SpamAssassin rule name */
-    Name: string;
-    /** Spam rule score */
-    Score: number;
-  }[];
+  /**
+   * Spam rules triggered and their score.
+   * @remarks The rules may return `null` if there is an error. Check the `Error` property for details.
+   */
+  Rules:
+    | {
+        /** SpamAssassin rule description */
+        Description: string;
+        /** SpamAssassin rule name */
+        Name: string;
+        /** Spam rule score */
+        Score: number;
+      }[]
+    | null;
   /** Total spam score based on triggered rules */
   Score: number;
 }


### PR DESCRIPTION
When spamAssassinCheck() returns an error the Rules property will be null.
Updates the interface to account for the error.