### PR TITLE
Implement waitForMessage and waitForMessages with options

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,9 +76,6 @@ test("should receive welcome email after registration", async ({
   page,
   mailpit,
 }) => {
-  // Start waiting for the new email event before triggering the action
-  const emailPromise = mailpit.waitForEvent("new");
-
   // Register a new user
   await page.goto("/register");
   await page.getByTestId("email").fill("test@example.test");
@@ -88,12 +85,54 @@ test("should receive welcome email after registration", async ({
   // Wait for success message on page
   await expect(page.getByTestId("success-message")).toBeVisible();
 
-  // Wait for the new email event (up to 5 seconds by default)
-  const event = await emailPromise;
+  // Wait for the welcome email (up to 5 seconds by default)
+  const message = await mailpit.waitForMessage({
+    query: "subject:Welcome to Our App",
+  });
 
-  // Verify the email from the event data
-  expect(event.Data.To[0].Address).toBe("test@example.test");
-  expect(event.Data.From.Address).toBe("no-reply@your-app.test");
-  expect(event.Data.Subject).toBe("Welcome to Our App");
+  // Verify the full message details
+  expect(message.To[0].Address).toBe("test@example.test");
+  expect(message.From.Address).toBe("no-reply@your-app.test");
+  expect(message.Subject).toBe("Welcome to Our App");
 });
+```
+
+### Waiting for Emails
+
+Choose the right method based on what you need:
+
+| Scenario                                                    | Method                         |
+| ----------------------------------------------------------- | ------------------------------ |
+| Wait for a specific message (by subject, sender, etc.)      | `waitForMessage()`             |
+| Wait for N messages to exist (optionally matching a search) | `waitForMessages()`            |
+| Real-time notification of any new message                   | `waitForEvent()` / `onEvent()` |
+
+```typescript
+// Wait for a specific message matching a search query — returns full message details
+const message = await mailpit.waitForMessage({
+  query: "to:user@example.test subject:Reset",
+});
+console.log(message.Subject);
+
+// Wait for exactly 3 messages to arrive matching a search query - returns all messages
+const response = await mailpit.waitForMessages({
+  query: "from:user@example.test",
+  count: 3,
+  exact: true,
+});
+console.log(response.messages_count); // 3
+console.log(response.messages[0].Subject); // Newest message
+
+// Real-time: react as soon as any new message arrives (no polling)
+const unsubscribe = mailpit.onEvent("new", (event) => {
+  console.log("New message arrived: ", event.Data.Subject);
+});
+// Stop listening when no longer needed
+unsubscribe();
+
+// Or as a one-shot promise (useful before triggering an action)
+const eventPromise = mailpit.waitForEvent("new");
+await triggerSomeAction();
+const event = await eventPromise;
+console.log("New message arrived: ", event.Data.Subject);
 ```

--- a/src/index.ts
+++ b/src/index.ts
@@ -426,6 +426,30 @@ export interface MailpitSearchMessagesRequest extends MailpitSearchRequest {
   limit?: number;
 }
 
+/** Options for the {@link MailpitClient.waitForMessage | waitForMessage()} API. */
+export interface MailpitWaitForMessageRequest {
+  /** Maximum time to wait in milliseconds. Pass `Infinity` to disable timeout. @defaultValue 5000 */
+  timeout?: number;
+  /** Polling interval in milliseconds. @defaultValue 500 */
+  interval?: number;
+}
+
+/** Request parameters for the {@link MailpitClient.waitForMessages | waitForMessages()} API. */
+export interface MailpitWaitForMessagesRequest {
+  /** Optional {@link https://mailpit.axllent.org/docs/usage/search-filters/ | Search query}. If omitted, polls all messages. */
+  query?: string;
+  /** Pagination offset */
+  start?: number;
+  /** Limit results */
+  limit?: number;
+  /** {@link https://en.wikipedia.org/wiki/List_of_tz_database_time_zones | Timezone identifier} used only for `before:` & `after:` searches (eg: "Pacific/Auckland"). */
+  tz?: string;
+  /** Number of messages to wait for. @defaultValue 1 */
+  count?: number;
+  /** If `true`, require `messages_count === count`. If `false` (default), require `messages_count >= count`. When `count` is `0`, always uses exact match regardless of this option. @defaultValue false */
+  exact?: boolean;
+}
+
 /** Request parameters for the {@link MailpitClient.setTags | setTags()} API. */
 export interface MailpitSetTagsRequest {
   /** Array of message database IDs */
@@ -981,6 +1005,138 @@ export class MailpitClient {
   }
 
   /**
+   * Waits for at least one message matching a search query, then returns the latest matching message.
+   * @remarks
+   * Polls the {@link MailpitClient.searchMessages | searchMessages()} API at a configurable interval until at least one message is found,
+   * then retrieves the full message details via {@link MailpitClient.getMessageSummary | getMessageSummary()}.
+   * The promise will reject if the timeout is reached before a matching message is found.
+   * @see {@link https://mailpit.axllent.org/docs/usage/search-filters/ | Search filters}
+   * @param search - The search request containing the query and optional parameters.
+   * @param options - Optional timeout and interval settings.
+   * @returns The full message summary of the latest matching message.
+   * @example
+   * ```typescript
+   * // Trigger an email, then wait for it
+   * await mailpit.sendMessage({
+   *   From: { Email: "test@example.test" },
+   *   To: [{ Email: "recipient@example.test" }],
+   *   Subject: "Welcome",
+   * });
+   * const message = await mailpit.waitForMessage({ query: "subject:Welcome" });
+   * console.log(message.Subject); // "Welcome"
+   * ```
+   */
+  public async waitForMessage(
+    search: MailpitSearchMessagesRequest,
+    options?: MailpitWaitForMessageRequest,
+  ): Promise<MailpitMessageSummaryResponse> {
+    const { timeout = 5_000, interval = 500 } = { ...options };
+    const endTime = performance.now() + timeout;
+    while (performance.now() < endTime) {
+      const result = await this.searchMessages(search);
+      if (result.messages_count >= 1 && result.messages.length > 0) {
+        return this.getMessageSummary(result.messages[0].ID);
+      }
+      await new Promise((resolve) => setTimeout(resolve, interval));
+    }
+    throw new Error(
+      `Timeout waiting for messages matching query "${search.query}"`,
+    );
+  }
+
+  /**
+   * Waits for a specific number of messages to exist, optionally matching a search query.
+   * @remarks
+   * Polls the {@link MailpitClient.searchMessages | searchMessages()} (if search is provided) or
+   * {@link MailpitClient.listMessages | listMessages()} API at a configurable interval until the count condition is met.
+   * The promise will reject if the timeout is reached before the condition is satisfied.
+   *
+   * By default, resolves when `messages_count >= count`. Set `exact: true` to require `messages_count === count`.
+   * When `count` is `0`, always uses exact match (`messages_count === 0`) regardless of the `exact` option.
+   * @see {@link https://mailpit.axllent.org/docs/usage/search-filters/ | Search filters}
+   * @param request - Optional request containing an optional search query, count, and exact match settings.
+   * @param options - Optional timeout and interval settings.
+   * @returns The message list response that satisfied the count condition.
+   * @example Wait for at least two messages matching a search
+   * ```typescript
+   * const response = await mailpit.waitForMessages({ query: "to:user@example.test", count: 2 });
+   * console.log(response.messages_count); // 2 or more
+   * ```
+   * @example Wait for exactly three messages matching a search
+   * ```typescript
+   * const response = await mailpit.waitForMessages({ query: "from:example.test", count: 3, exact: true });
+   * console.log(response.messages_count); // 3
+   * ```
+   * @example Wait for an empty mailbox
+   * ```typescript
+   * await mailpit.deleteMessages();
+   * const response = await mailpit.waitForMessages({ count: 0 });
+   * console.log(response.messages_count); // 0
+   * ```
+   * @example Wait until no messages match a search query
+   * ```typescript
+   * await mailpit.deleteMessagesBySearch({ query: "from:example.test" });
+   * const response = await mailpit.waitForMessages({ query: "from:example.test", count: 0 });
+   * console.log(response.messages_count); // 0
+   * ```
+   * @example Wait for at least one message with a custom timeout and interval only
+   * ```typescript
+   * const response = await mailpit.waitForMessages({ timeout: 10_000, interval: 1_000 });
+   * console.log(response.messages_count); // 1 or more
+   * ```
+   */
+  public async waitForMessages(
+    options?: MailpitWaitForMessageRequest,
+  ): Promise<MailpitMessagesSummaryResponse>;
+  public async waitForMessages(
+    request: MailpitWaitForMessagesRequest,
+    options?: MailpitWaitForMessageRequest,
+  ): Promise<MailpitMessagesSummaryResponse>;
+  public async waitForMessages(
+    requestOrOptions?:
+      | MailpitWaitForMessagesRequest
+      | MailpitWaitForMessageRequest,
+    options?: MailpitWaitForMessageRequest,
+  ): Promise<MailpitMessagesSummaryResponse> {
+    const isOptionsOnly =
+      !requestOrOptions ||
+      "timeout" in requestOrOptions ||
+      "interval" in requestOrOptions;
+    const request = isOptionsOnly
+      ? undefined
+      : (requestOrOptions as MailpitWaitForMessagesRequest);
+    const opts = isOptionsOnly
+      ? (requestOrOptions as MailpitWaitForMessageRequest)
+      : options;
+    const {
+      query,
+      start,
+      limit,
+      tz,
+      count = 1,
+      exact = false,
+    } = { ...request };
+    const { timeout = 5_000, interval = 500 } = { ...opts };
+    const endTime = performance.now() + timeout;
+
+    const predicate: (r: MailpitMessagesSummaryResponse) => boolean =
+      count === 0 || exact
+        ? (r) => r.messages_count === count
+        : (r) => r.messages_count >= count;
+
+    while (performance.now() < endTime) {
+      const result = query
+        ? await this.searchMessages({ query, start, limit, tz })
+        : await this.listMessages(start, limit);
+      if (predicate(result)) return result;
+      await new Promise((resolve) => setTimeout(resolve, interval));
+    }
+    throw new Error(
+      `Timeout waiting for messages${query ? ` matching query "${query}"` : ""}`,
+    );
+  }
+
+  /**
    * Delete all messages matching a search.
    * @see {@link https://mailpit.axllent.org/docs/usage/search-filters/ | Search filters}
    * @param search - The search request containing the query.
@@ -1405,8 +1561,8 @@ export class MailpitClient {
    *
    * // Do something that triggers an email to send
    * await mailpit.sendMessage({
-   *   From: { Email: "test@example.com" },
-   *   To: [{ Email: "recipient@example.com" }],
+   *   From: { Email: "test@example.test" },
+   *   To: [{ Email: "recipient@example.test" }],
    *   Subject: "Test",
    * });
    *

--- a/tests/index.spec.ts
+++ b/tests/index.spec.ts
@@ -48,6 +48,8 @@ describe("MailpitClient", () => {
       eventType: string,
       timeout?: number,
     ) => Promise<{ Type: string; Data: unknown }>;
+    waitForMessage: InstanceType<typeof MailpitClient>["waitForMessage"];
+    waitForMessages: InstanceType<typeof MailpitClient>["waitForMessages"];
     eventListeners: Map<
       string,
       Set<(event: { Type: string; Data: unknown }) => void>
@@ -339,5 +341,159 @@ describe("MailpitClient", () => {
 
     // Verify listener was never called (malformed message was silently ignored)
     expect(mockListener).not.toHaveBeenCalled();
+  });
+
+  // Mock response for message list polling
+  const mockEmptyMessages = {
+    messages: [],
+    messages_count: 0,
+    messages_unread: 0,
+    start: 0,
+    tags: [],
+    total: 0,
+    unread: 0,
+    count: 0,
+  };
+
+  const mockMessagesWithCount = (count: number) => ({
+    messages: Array.from({ length: count }, (_, i) => ({
+      ID: `msg-${String(i + 1)}`,
+      Subject: `Message ${String(i + 1)}`,
+    })),
+    messages_count: count,
+    messages_unread: count,
+    start: 0,
+    tags: [],
+    total: count,
+    unread: count,
+    count,
+  });
+
+  const mockFullMessage = {
+    ID: "msg-1",
+    Subject: "Test",
+    From: { Email: "test@example.test", Name: "Test" },
+    To: [{ Email: "recipient@example.test", Name: "Recipient" }],
+    HTML: "<p>Hello</p>",
+    Text: "Hello",
+  };
+
+  test("waitForMessage() should poll until a message appears", async () => {
+    mockedAxios.get
+      .mockResolvedValueOnce({ data: mockEmptyMessages }) // first poll: no messages
+      .mockResolvedValueOnce({ data: mockMessagesWithCount(1) }) // second poll: found
+      .mockResolvedValueOnce({ data: mockFullMessage }); // getMessageSummary
+
+    const result = await internalClient.waitForMessage({
+      query: "subject:Test",
+    });
+
+    expect(mockedAxios.get).toHaveBeenCalledWith("/api/v1/search", {
+      params: { query: "subject:Test" },
+    });
+    expect(mockedAxios.get).toHaveBeenCalledWith("/api/v1/message/msg-1");
+    expect(mockedAxios.get).toHaveBeenCalledTimes(3);
+    expect(result).toEqual(mockFullMessage);
+  });
+
+  test("waitForMessage() should timeout when no messages match", async () => {
+    mockedAxios.get.mockResolvedValue({ data: mockEmptyMessages });
+
+    await expect(
+      internalClient.waitForMessage(
+        { query: "subject:NonExistent" },
+        { timeout: 150, interval: 50 },
+      ),
+    ).rejects.toThrow(
+      'Timeout waiting for messages matching query "subject:NonExistent"',
+    );
+  });
+
+  test("waitForMessages() should use listMessages() by default and resolve when condition met", async () => {
+    mockedAxios.get.mockResolvedValueOnce({ data: mockMessagesWithCount(1) });
+
+    const result = await internalClient.waitForMessages();
+
+    expect(result.messages_count).toBe(1);
+    expect(mockedAxios.get).toHaveBeenCalledWith("/api/v1/messages", {
+      params: { start: 0, limit: 50 },
+    });
+  });
+
+  test("waitForMessages() should use searchMessages() when search provided", async () => {
+    mockedAxios.get.mockResolvedValueOnce({ data: mockMessagesWithCount(1) });
+
+    await internalClient.waitForMessages(
+      { query: "from:test@example.test" },
+      { timeout: 1000, interval: 50 },
+    );
+
+    expect(mockedAxios.get).toHaveBeenCalledWith("/api/v1/search", {
+      params: { query: "from:test@example.test" },
+    });
+  });
+
+  test("waitForMessages() with exact: true or count: 0 should require exact count", async () => {
+    // exact: true — skips count=3 (too many), resolves on count=2
+    mockedAxios.get
+      .mockResolvedValueOnce({ data: mockMessagesWithCount(3) })
+      .mockResolvedValueOnce({ data: mockMessagesWithCount(2) });
+
+    const exactResult = await internalClient.waitForMessages(
+      { count: 2, exact: true },
+      { timeout: 1000, interval: 50 },
+    );
+    expect(exactResult.messages_count).toBe(2);
+    expect(mockedAxios.get).toHaveBeenCalledTimes(2);
+
+    jest.clearAllMocks();
+
+    // count: 0 — skips non-empty, resolves when empty
+    mockedAxios.get
+      .mockResolvedValueOnce({ data: mockMessagesWithCount(1) })
+      .mockResolvedValueOnce({ data: mockEmptyMessages });
+
+    const zeroResult = await internalClient.waitForMessages(
+      { count: 0 },
+      { timeout: 1000, interval: 50 },
+    );
+    expect(zeroResult.messages_count).toBe(0);
+    expect(mockedAxios.get).toHaveBeenCalledTimes(2);
+  });
+
+  test("waitForMessages() should not timeout when passed Infinity", async () => {
+    mockedAxios.get
+      .mockResolvedValueOnce({ data: mockEmptyMessages })
+      .mockResolvedValueOnce({ data: mockEmptyMessages })
+      .mockResolvedValueOnce({ data: mockMessagesWithCount(1) });
+
+    const result = await internalClient.waitForMessages({
+      timeout: Infinity,
+      interval: 50,
+    });
+
+    expect(result.messages_count).toBe(1);
+  });
+
+  test("waitForMessages() should timeout with error message including query if provided", async () => {
+    mockedAxios.get.mockResolvedValue({ data: mockMessagesWithCount(1) });
+
+    // Without query — generic timeout message
+    await expect(
+      internalClient.waitForMessages(
+        { count: 5 },
+        { timeout: 150, interval: 50 },
+      ),
+    ).rejects.toThrow("Timeout waiting for messages");
+
+    // With query — error message includes the query string
+    await expect(
+      internalClient.waitForMessages(
+        { query: "from:nobody@example.test", count: 5 },
+        { timeout: 150, interval: 50 },
+      ),
+    ).rejects.toThrow(
+      'Timeout waiting for messages matching query "from:nobody@example.test"',
+    );
   });
 });


### PR DESCRIPTION
Added `waitForMessage()` and `waitForMessages()` methods to `MailpitClient`, enabling polling for messages matching a search query or waiting for a specific count of messages, with configurable timeout and interval options.