### PR TITLE
fix: update cron schedule and simplify variables in test workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,21 +6,9 @@ permissions:
 
 on:
   workflow_call:
-    inputs:
-      username:
-        required: true
-        type: string
-    secrets:
-      password:
-        required: true
   schedule:
-    - cron: "0 21 * * 5" # Every Friday at 9 PM UTC
+    - cron: "0 15 * * 3" # Every Wednesday at 3 PM UTC
   workflow_dispatch:
-    inputs:
-      username:
-        description: "Username for Mailpit"
-        required: false
-        type: string
   pull_request:
     branches: ["main"]
     types: [opened, synchronize, reopened]
@@ -45,8 +33,8 @@ jobs:
         node-version: [18, 20, 22, 24] # legacy, maintenance, lts, current
     name: Node ${{ matrix.node-version }} Test
     env:
-      USERNAME: ${{ inputs.username || github.event.inputs.username || github.actor }}
-      PASSWORD: ${{ secrets.password || secrets.MP_PASSWORD }}
+      USERNAME: ${{ github.actor }}
+      PASSWORD: ${{ github.run_id }}
     services:
       mailpit:
         image: axllent/mailpit
@@ -64,11 +52,12 @@ jobs:
           node-version: 24
           cache: "npm"
           cache-dependency-path: "**/package-lock.json"
-      - run: npm ci
+      - run: npm ci --ignore-scripts
       - name: Update dependencies to latest
         if: github.event_name == 'schedule'
         run: |
-          npm update
+          npm update --ignore-scripts
+          npm audit --audit-level=high
           npm ls --depth=0
       - name: Run All Tests
         run: npm run test


### PR DESCRIPTION
- Change the cron schedule
- Simplify temporary throw away variables
- Add `--ignore-scripts` flag to npm command