### PR TITLE
allow baseUrl to have relative path part

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -749,7 +749,7 @@ export class MailpitClient {
    */
   public async getInfo(): Promise<MailpitInfoResponse> {
     return await this.handleRequest(() =>
-      this.axiosInstance.get<MailpitInfoResponse>("/api/v1/info"),
+      this.axiosInstance.get<MailpitInfoResponse>("api/v1/info"),
     );
   }
 
@@ -764,7 +764,7 @@ export class MailpitClient {
    */
   public async getConfiguration(): Promise<MailpitConfigurationResponse> {
     return await this.handleRequest(() =>
-      this.axiosInstance.get<MailpitConfigurationResponse>("/api/v1/webui"),
+      this.axiosInstance.get<MailpitConfigurationResponse>("api/v1/webui"),
     );
   }
 
@@ -782,7 +782,7 @@ export class MailpitClient {
   ): Promise<MailpitMessageSummaryResponse> {
     return await this.handleRequest(() =>
       this.axiosInstance.get<MailpitMessageSummaryResponse>(
-        `/api/v1/message/${id}`,
+        `api/v1/message/${id}`,
       ),
     );
   }
@@ -802,7 +802,7 @@ export class MailpitClient {
   ): Promise<MailpitMessageHeadersResponse> {
     return await this.handleRequest(() =>
       this.axiosInstance.get<MailpitMessageHeadersResponse>(
-        `/api/v1/message/${id}/headers`,
+        `api/v1/message/${id}/headers`,
       ),
     );
   }
@@ -828,7 +828,7 @@ export class MailpitClient {
     const response = await this.handleRequest(
       () =>
         this.axiosInstance.get<ArrayBuffer>(
-          `/api/v1/message/${id}/part/${partID}`,
+          `api/v1/message/${id}/part/${partID}`,
           { responseType: "arraybuffer" },
         ),
       { fullResponse: true },
@@ -864,7 +864,7 @@ export class MailpitClient {
     const response = await this.handleRequest(
       () =>
         this.axiosInstance.get<ArrayBuffer>(
-          `/api/v1/message/${id}/part/${partID}/thumb`,
+          `api/v1/message/${id}/part/${partID}/thumb`,
           {
             responseType: "arraybuffer",
           },
@@ -888,7 +888,7 @@ export class MailpitClient {
    */
   public async getMessageSource(id: string = "latest"): Promise<string> {
     return await this.handleRequest(() =>
-      this.axiosInstance.get<string>(`/api/v1/message/${id}/raw`),
+      this.axiosInstance.get<string>(`api/v1/message/${id}/raw`),
     );
   }
 
@@ -908,7 +908,7 @@ export class MailpitClient {
     relayTo: { To: string[] },
   ): Promise<string> {
     return await this.handleRequest(() =>
-      this.axiosInstance.post<string>(`/api/v1/message/${id}/release`, relayTo),
+      this.axiosInstance.post<string>(`api/v1/message/${id}/release`, relayTo),
     );
   }
 
@@ -930,7 +930,7 @@ export class MailpitClient {
   ): Promise<MailpitSendMessageConfirmationResponse> {
     return await this.handleRequest(() =>
       this.axiosInstance.post<MailpitSendMessageConfirmationResponse>(
-        `/api/v1/send`,
+        `api/v1/send`,
         sendRequest,
       ),
     );
@@ -954,7 +954,7 @@ export class MailpitClient {
   ): Promise<MailpitMessagesSummaryResponse> {
     return await this.handleRequest(() =>
       this.axiosInstance.get<MailpitMessagesSummaryResponse>(
-        `/api/v1/messages`,
+        `api/v1/messages`,
         { params: { start, limit } },
       ),
     );
@@ -993,7 +993,7 @@ export class MailpitClient {
     params?: MailpitTimeZoneRequest,
   ): Promise<string> {
     return await this.handleRequest(() =>
-      this.axiosInstance.put<string>(`/api/v1/messages`, readStatus, {
+      this.axiosInstance.put<string>(`api/v1/messages`, readStatus, {
         params,
       }),
     );
@@ -1017,7 +1017,7 @@ export class MailpitClient {
     deleteRequest?: MailpitDatabaseIDsRequest,
   ): Promise<string> {
     return await this.handleRequest(() =>
-      this.axiosInstance.delete<string>(`/api/v1/messages`, {
+      this.axiosInstance.delete<string>(`api/v1/messages`, {
         data: deleteRequest,
       }),
     );
@@ -1040,7 +1040,7 @@ export class MailpitClient {
     search: MailpitSearchMessagesRequest,
   ): Promise<MailpitMessagesSummaryResponse> {
     return await this.handleRequest(() =>
-      this.axiosInstance.get<MailpitMessagesSummaryResponse>(`/api/v1/search`, {
+      this.axiosInstance.get<MailpitMessagesSummaryResponse>(`api/v1/search`, {
         params: search,
       }),
     );
@@ -1193,7 +1193,7 @@ export class MailpitClient {
     search: MailpitSearchRequest,
   ): Promise<string> {
     return await this.handleRequest(() =>
-      this.axiosInstance.delete<string>(`/api/v1/search`, { params: search }),
+      this.axiosInstance.delete<string>(`api/v1/search`, { params: search }),
     );
   }
 
@@ -1211,7 +1211,7 @@ export class MailpitClient {
   ): Promise<MailpitHTMLCheckResponse> {
     return await this.handleRequest(() =>
       this.axiosInstance.get<MailpitHTMLCheckResponse>(
-        `/api/v1/message/${id}/html-check`,
+        `api/v1/message/${id}/html-check`,
       ),
     );
   }
@@ -1232,7 +1232,7 @@ export class MailpitClient {
   ): Promise<MailpitLinkCheckResponse> {
     return await this.handleRequest(() =>
       this.axiosInstance.get<MailpitLinkCheckResponse>(
-        `/api/v1/message/${id}/link-check`,
+        `api/v1/message/${id}/link-check`,
         { params: { follow } },
       ),
     );
@@ -1252,7 +1252,7 @@ export class MailpitClient {
   ): Promise<MailpitSpamAssassinResponse> {
     return await this.handleRequest(() =>
       this.axiosInstance.get<MailpitSpamAssassinResponse>(
-        `/api/v1/message/${id}/sa-check`,
+        `api/v1/message/${id}/sa-check`,
       ),
     );
   }
@@ -1267,7 +1267,7 @@ export class MailpitClient {
    */
   public async getTags(): Promise<string[]> {
     return await this.handleRequest(() =>
-      this.axiosInstance.get<string[]>(`/api/v1/tags`),
+      this.axiosInstance.get<string[]>(`api/v1/tags`),
     );
   }
 
@@ -1288,7 +1288,7 @@ export class MailpitClient {
    */
   public async setTags(request: MailpitSetTagsRequest): Promise<string> {
     return await this.handleRequest(() =>
-      this.axiosInstance.put<string>(`/api/v1/tags`, request),
+      this.axiosInstance.put<string>(`api/v1/tags`, request),
     );
   }
 
@@ -1308,7 +1308,7 @@ export class MailpitClient {
   public async renameTag(tag: string, newTagName: string): Promise<string> {
     const encodedTag = encodeURIComponent(tag);
     return await this.handleRequest(() =>
-      this.axiosInstance.put<string>(`/api/v1/tags/${encodedTag}`, {
+      this.axiosInstance.put<string>(`api/v1/tags/${encodedTag}`, {
         Name: newTagName,
       }),
     );
@@ -1327,7 +1327,7 @@ export class MailpitClient {
   public async deleteTag(tag: string): Promise<string> {
     const encodedTag = encodeURIComponent(tag);
     return await this.handleRequest(() =>
-      this.axiosInstance.delete<string>(`/api/v1/tags/${encodedTag}`),
+      this.axiosInstance.delete<string>(`api/v1/tags/${encodedTag}`),
     );
   }
 
@@ -1342,7 +1342,7 @@ export class MailpitClient {
    */
   public async getChaosTriggers(): Promise<MailpitChaosTriggersResponse> {
     return await this.handleRequest(() =>
-      this.axiosInstance.get<MailpitChaosTriggersResponse>("/api/v1/chaos"),
+      this.axiosInstance.get<MailpitChaosTriggersResponse>("api/v1/chaos"),
     );
   }
 
@@ -1364,7 +1364,7 @@ export class MailpitClient {
   ): Promise<MailpitChaosTriggersResponse> {
     return await this.handleRequest(() =>
       this.axiosInstance.put<MailpitChaosTriggersResponse>(
-        "/api/v1/chaos",
+        "api/v1/chaos",
         triggers,
       ),
     );

--- a/tests/index.e2e.spec.ts
+++ b/tests/index.e2e.spec.ts
@@ -642,7 +642,7 @@ describe("MailpitClient E2E Tests", () => {
     test("invalid host (request)", async () => {
       const invalidUrlMailpit = new MailpitClient("http://invalid-host:9999");
       await expect(invalidUrlMailpit.getInfo()).rejects.toThrow(
-        "Mailpit API Error: No response received from server at GET /api/v1/info",
+        "Mailpit API Error: No response received from server at GET api/v1/info",
       );
     });
   });

--- a/tests/index.spec.ts
+++ b/tests/index.spec.ts
@@ -96,7 +96,7 @@ describe("MailpitClient", () => {
     mockedAxios.put.mockResolvedValue({ data: "ok" });
     const result = await client.setReadStatus();
     expect(mockedAxios.put).toHaveBeenCalledWith(
-      "/api/v1/messages",
+      "api/v1/messages",
       {},
       {
         params: undefined,
@@ -110,7 +110,7 @@ describe("MailpitClient", () => {
     mockedAxios.post.mockResolvedValue({ data: "ok" });
     const result = await client.releaseMessage("id", { To: ["a@b.com"] });
     expect(mockedAxios.post).toHaveBeenCalledWith(
-      "/api/v1/message/id/release",
+      "api/v1/message/id/release",
       { To: ["a@b.com"] },
     );
     expect(result).toBe("ok");
@@ -121,7 +121,7 @@ describe("MailpitClient", () => {
     mockedAxios.get.mockResolvedValue({ data: mockData });
     const result = await client.spamAssassinCheck();
     expect(mockedAxios.get).toHaveBeenCalledWith(
-      "/api/v1/message/latest/sa-check",
+      "api/v1/message/latest/sa-check",
     );
     expect(result).toEqual(mockData);
   });
@@ -144,14 +144,14 @@ describe("MailpitClient", () => {
   test("should call getChaosTriggers() and return triggers", async () => {
     mockedAxios.get.mockResolvedValue({ data: mockData });
     const result = await client.getChaosTriggers();
-    expect(mockedAxios.get).toHaveBeenCalledWith("/api/v1/chaos");
+    expect(mockedAxios.get).toHaveBeenCalledWith("api/v1/chaos");
     expect(result).toEqual(mockData);
   });
 
   test("should call setChaosTriggers() and return ok", async () => {
     mockedAxios.put.mockResolvedValue({ data: mockData });
     const result = await client.setChaosTriggers();
-    expect(mockedAxios.put).toHaveBeenCalledWith("/api/v1/chaos", {});
+    expect(mockedAxios.put).toHaveBeenCalledWith("api/v1/chaos", {});
     expect(result).toEqual(mockData);
   });
 
@@ -165,7 +165,7 @@ describe("MailpitClient", () => {
     const error = {
       name: "AxiosError",
       message: "Response Error",
-      config: { url: "/api/v1/info", method: "GET" },
+      config: { url: "api/v1/info", method: "GET" },
       response: {
         status: 500,
         data: "Boom!",
@@ -175,19 +175,19 @@ describe("MailpitClient", () => {
     };
     mockedAxios.get.mockRejectedValue(error);
     await expect(client.getInfo()).rejects.toThrow(
-      'Mailpit API Error: 500 Internal Server Error at GET /api/v1/info: "Boom!"',
+      'Mailpit API Error: 500 Internal Server Error at GET api/v1/info: "Boom!"',
     );
   });
 
   test("should handle AxiosError without a response but with a request", async () => {
     const error = {
       name: "AxiosError",
-      config: { url: "/api/v1/info", method: "GET" },
+      config: { url: "api/v1/info", method: "GET" },
       request: {},
     };
     mockedAxios.get.mockRejectedValue(error);
     await expect(client.getInfo()).rejects.toThrow(
-      "Mailpit API Error: No response received from server at GET /api/v1/info",
+      "Mailpit API Error: No response received from server at GET api/v1/info",
     );
   });
 
@@ -441,10 +441,10 @@ describe("MailpitClient", () => {
       query: "subject:Test",
     });
 
-    expect(mockedAxios.get).toHaveBeenCalledWith("/api/v1/search", {
+    expect(mockedAxios.get).toHaveBeenCalledWith("api/v1/search", {
       params: { query: "subject:Test" },
     });
-    expect(mockedAxios.get).toHaveBeenCalledWith("/api/v1/message/msg-1");
+    expect(mockedAxios.get).toHaveBeenCalledWith("api/v1/message/msg-1");
     expect(mockedAxios.get).toHaveBeenCalledTimes(3);
     expect(result).toEqual(mockFullMessage);
   });
@@ -468,7 +468,7 @@ describe("MailpitClient", () => {
     const result = await internalClient.waitForMessages();
 
     expect(result.messages_count).toBe(1);
-    expect(mockedAxios.get).toHaveBeenCalledWith("/api/v1/messages", {
+    expect(mockedAxios.get).toHaveBeenCalledWith("api/v1/messages", {
       params: { start: 0, limit: 50 },
     });
   });
@@ -481,7 +481,7 @@ describe("MailpitClient", () => {
       { timeout: 1000, interval: 50 },
     );
 
-    expect(mockedAxios.get).toHaveBeenCalledWith("/api/v1/search", {
+    expect(mockedAxios.get).toHaveBeenCalledWith("api/v1/search", {
       params: { query: "from:test@example.test" },
     });
   });


### PR DESCRIPTION
Hey, it's me again.

I seem to have another issue with your package that relates to the way we run Mailpit. In our end-to-end test pipeline, we run Mailpit under a URL with a path segment (`https://example.de/mailpit`), but axios overwrites the path segment of the base URL when it is passed a relative path with a leading slash. Removing the leading slash should fix the problem. I took the liberty of just going ahead and doing it.

If you'd like it done differently, I'd be happy to make some adjustments.