### PR TITLE
fix: remove trailing slashes from WebSocket URL

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -678,7 +678,7 @@ export class MailpitClient {
     }
 
     this.baseURL = baseURL;
-    this.wsURL = `${baseURL.replace(/^http/, "ws")}/api/events`;
+    this.wsURL = `${baseURL.replace(/^http/, "ws").replace(/\/?\/$/, "")}/api/events`;
 
     this.axiosInstance = axios.create({
       ...axiosConfig,

--- a/tests/index.e2e.spec.ts
+++ b/tests/index.e2e.spec.ts
@@ -13,13 +13,13 @@ dotenv.config();
 
 describe("MailpitClient E2E Tests", () => {
   // Ensure required environment variables are set
-  const { HOST = "localhost", PORT = "8025", USERNAME, PASSWORD } = process.env;
+  const { BASEURL = "http://localhost:8025", USERNAME, PASSWORD } = process.env;
   if (!USERNAME || !PASSWORD) {
     throw new Error("Missing required environment variables");
   }
 
   // Initialize MailpitClient with environment variables
-  const mailpit = new MailpitClient(`http://${HOST}:${PORT}`, {
+  const mailpit = new MailpitClient(BASEURL, {
     username: USERNAME,
     password: PASSWORD,
   });
@@ -629,7 +629,7 @@ describe("MailpitClient E2E Tests", () => {
     test("invalid authentication (response)", async () => {
       // Note: This test only works if Mailpit has authentication enabled.
       // If authentication is disabled, this test will pass by default.
-      const invalidAuthMailpit = new MailpitClient(`http://${HOST}:${PORT}`, {
+      const invalidAuthMailpit = new MailpitClient(BASEURL, {
         username: "invalid-user",
         password: "invalid-password",
       });


### PR DESCRIPTION
Remove trailing slashes from the end of the WebSocket base URL. Also, update E2E tests to accept BASEURL as an env variable instead of the HOST and PORT seperately. This allows running the test against Mailpit urls that do not contain a port.