### PR TITLE
fix(mailpit-ws): resolve connection race in onEvent() and waitForEvent()

### DIFF
--- a/packages/mailpit-api/tests/index.spec.ts
+++ b/packages/mailpit-api/tests/index.spec.ts
@@ -137,7 +137,7 @@ describe("MailpitClient", () => {
       text: () => Promise.reject(new Error("stream error")),
       blob: () => Promise.reject(new Error("stream error")),
       headers: new Headers(),
-    } as unknown as Response);
+    });
     await expect(client.getInfo()).rejects.toThrow(
       "Mailpit API Error: SyntaxError: Unexpected token at GET http://localhost:8025/api/v1/info",
     );

--- a/packages/mailpit-ws/README.md
+++ b/packages/mailpit-ws/README.md
@@ -12,10 +12,10 @@ For the REST API client, see [`mailpit-api`](https://www.npmjs.com/package/mailp
 ## Installation
 
 ```bash
-npm install mailpit-api mailpit-ws
+npm install mailpit-ws
 ```
 
-> `mailpit-api` is a peer dependency (required for shared types).
+> `mailpit-api` is a peer dependency. You may need to install it separately if your package manager does not auto-install peer dependencies.
 
 ## Documentation
 
@@ -32,10 +32,15 @@ import { MailpitEvents } from "mailpit-ws";
 
 const events = new MailpitEvents("http://localhost:8025");
 
-// Listen for new messages
+// Register listener before connecting so no events are missed
 const unsubscribe = events.onEvent("new", (event) => {
   console.log("New message:", event.Data.Subject);
 });
+
+// Ensure the socket is open before triggering any action that generates events
+await events.connect();
+
+// trigger app action that sends an email...
 
 // Stop listening
 unsubscribe();
@@ -44,18 +49,35 @@ unsubscribe();
 events.disconnect();
 ```
 
-### Waiting for a Specific Event
+### Playwright Fixture Pattern
+
+If you are using Playwright fixtures, connect once in fixture setup and await it before any test actions run:
 
 ```typescript
+import { test as base } from "@playwright/test";
 import { MailpitEvents } from "mailpit-ws";
 
-const events = new MailpitEvents("http://localhost:8025");
+type Fixtures = { events: MailpitEvents };
 
-// Wait for the next new message event (5 second timeout by default)
-const event = await events.waitForEvent("new");
-console.log("Received:", event.Data.Subject);
+export const test = base.extend<Fixtures>({
+  events: async ({}, use) => {
+    const events = new MailpitEvents("http://localhost:8025");
 
-events.disconnect();
+    // Ensure socket is ready before any test step can trigger events
+    await events.connect();
+
+    await use(events);
+    events.disconnect();
+  },
+});
+
+// In tests: register listeners, then trigger actions
+test("captures new message event", async ({ events }) => {
+  const newEventPromise = events.waitForEvent("new");
+  // trigger app action that sends an email...
+  const newEvent = await newEventPromise;
+  console.log(newEvent.Type);
+});
 ```
 
 ### Event Types
@@ -81,6 +103,6 @@ const events = new MailpitEvents("http://localhost:8025", {
 });
 ```
 
-### Browser Note
+#### Browser Note
 
 > Basic authentication is **not supported for WebSocket connections in browsers**. The native `WebSocket` API does not allow custom headers. This limitation does not apply to Node.js.

--- a/packages/mailpit-ws/src/index.ts
+++ b/packages/mailpit-ws/src/index.ts
@@ -252,75 +252,132 @@ export class MailpitEvents {
    * Connects to the WebSocket endpoint for receiving real-time events.
    * @remarks
    * Called automatically by {@link MailpitEvents.onEvent | onEvent()} and {@link MailpitEvents.waitForEvent | waitForEvent()}.
-   * You only need to call this directly if you want to establish the connection before registering listeners.
+   *
+   * Returns a `Promise<void>` that resolves once the connection is open. Await this
+   * before triggering actions that generate events (e.g. sending an email) to avoid
+   * the race condition where the event is broadcast before the socket is ready:
+   *
+   * ```typescript
+   * // Register the listener first so no events are missed during the connection phase
+   * const eventPromise = events.waitForEvent("new");
+   * // Then ensure the socket is open before triggering the action
+   * await events.connect();
+   * await mailpit.sendMessage({ ... });
+   * const event = await eventPromise;
+   * ```
+   *
+   * If the socket is already open the returned Promise resolves immediately.
+   * @returns A Promise that resolves when the WebSocket connection is open.
    */
-  public connect(): void {
-    // Return if already connected or connecting
-    if (
-      this.webSocket &&
-      (this.webSocket.readyState === ReconnectingWebSocket.OPEN ||
-        this.webSocket.readyState === ReconnectingWebSocket.CONNECTING)
-    ) {
-      return;
+  public connect(): Promise<void> {
+    // Already open - resolve immediately
+    if (this.webSocket?.readyState === ReconnectingWebSocket.OPEN) {
+      return Promise.resolve();
     }
 
-    // Capture private fields for use inside the nested class constructor below.
-    const authHeader = this.#authHeader;
-    const userWsOptions = this.#userWsOptions;
+    // Create a fresh connection when there is no socket, it is fully closed, or
+    // it is closing (a CLOSING socket will never emit open again).
+    if (
+      !this.webSocket ||
+      this.webSocket.readyState === ReconnectingWebSocket.CLOSED ||
+      this.webSocket.readyState === ReconnectingWebSocket.CLOSING
+    ) {
+      // Capture private fields for use inside the nested class constructor below.
+      const authHeader = this.#authHeader;
+      const userWsOptions = this.#userWsOptions;
 
-    // In Node.js, build a custom WebSocket constructor that injects auth headers
-    // and merges any user-provided wsOptions. Browsers cannot set custom headers
-    // on WebSocket connections, so we skip this entirely when using native WebSocket.
-    const wsConstructor =
-      !IS_NATIVE_WEBSOCKET && (authHeader || userWsOptions)
-        ? class AuthenticatedWebSocket extends WS {
-            constructor(address: string, options?: WS.ClientOptions) {
-              super(address, {
-                ...userWsOptions,
-                ...options,
-                headers: {
-                  // User-provided headers from wsOptions and per-call options first,
-                  // then auth header last so it cannot be overridden.
-                  ...(userWsOptions?.headers as Record<string, string>),
-                  ...(options?.headers as Record<string, string>),
-                  ...(authHeader ? { Authorization: authHeader } : {}),
-                },
-              });
+      // In Node.js, build a custom WebSocket constructor that injects auth headers
+      // and merges any user-provided wsOptions. Browsers cannot set custom headers
+      // on WebSocket connections, so we skip this entirely when using native WebSocket.
+      const wsConstructor =
+        !IS_NATIVE_WEBSOCKET && (authHeader || userWsOptions)
+          ? class AuthenticatedWebSocket extends WS {
+              constructor(address: string, options?: WS.ClientOptions) {
+                super(address, {
+                  ...userWsOptions,
+                  ...options,
+                  headers: {
+                    // User-provided headers from wsOptions and per-call options first,
+                    // then auth header last so it cannot be overridden.
+                    ...(userWsOptions?.headers as Record<string, string>),
+                    ...(options?.headers as Record<string, string>),
+                    ...(authHeader ? { Authorization: authHeader } : {}),
+                  },
+                });
+              }
             }
-          }
-        : WS;
+          : WS;
 
-    this.webSocket = new ReconnectingWebSocket(
-      this.wsURL.toString(),
-      undefined,
-      {
+      const ws = new ReconnectingWebSocket(this.wsURL.toString(), undefined, {
         ...this.#reconnectOptions,
         // WebSocket constructor is always set last so users cannot override it
         // via reconnectOptions (Omit<Options, "WebSocket"> at the type level,
         // enforced here at runtime too).
         WebSocket: wsConstructor,
-      },
-    );
+      });
+      this.webSocket = ws;
 
-    this.webSocket.addEventListener("message", (event) => {
-      let message: MailpitEvent;
-      try {
-        message = JSON.parse(event.data as string) as MailpitEvent;
-      } catch {
-        // Silently ignore malformed messages from server
-        return;
-      }
-      this.handleWebSocketMessage(message);
-    });
+      ws.addEventListener("message", (event) => {
+        // Guard against stale listeners from a replaced socket instance.
+        if (this.webSocket !== ws) return;
+        let message: MailpitEvent;
+        try {
+          message = JSON.parse(event.data as string) as MailpitEvent;
+        } catch {
+          // Silently ignore malformed messages from server
+          return;
+        }
+        this.handleWebSocketMessage(message);
+      });
 
-    // Unref the underlying TCP socket and internal timers so the WebSocket
-    // does not prevent the Node.js process from exiting naturally. Called on
-    // every "open" event to cover both initial connections and reconnections.
-    this.webSocket.addEventListener("open", () => {
-      const rws = this.webSocket as unknown as ReconnectingWebSocketInternals;
-      rws._ws?._socket?.unref?.();
-      rws._uptimeTimeout?.unref?.();
-      rws._connectTimeout?.unref?.();
+      // Unref the underlying TCP socket and internal timers so the WebSocket
+      // does not prevent the Node.js process from exiting naturally. Called on
+      // every "open" event to cover both initial connections and reconnections.
+      ws.addEventListener("open", () => {
+        if (this.webSocket !== ws) return;
+        const rws = this.webSocket as unknown as ReconnectingWebSocketInternals;
+        rws._ws?._socket?.unref?.();
+        rws._uptimeTimeout?.unref?.();
+        rws._connectTimeout?.unref?.();
+      });
+    }
+
+    // Check again after construction - mocks or fast local connections may already be OPEN.
+    if (this.webSocket.readyState === ReconnectingWebSocket.OPEN) {
+      return Promise.resolve();
+    }
+
+    // Socket is CONNECTING - return a Promise that settles on the next terminal event.
+    // Resolves when open fires; rejects if the socket is abandoned (disconnect() called
+    // or replaced by a new connect() call) before the handshake completes.
+    // ReconnectingWebSocket fires close/error during normal reconnect cycles and then
+    // retries, so we only reject when this.webSocket has changed (not on transient events).
+    const ws = this.webSocket;
+    return new Promise<void>((resolve, reject) => {
+      const cleanup = () => {
+        ws.removeEventListener("open", onOpen);
+        ws.removeEventListener("close", onClose);
+      };
+
+      const onOpen = () => {
+        if (this.webSocket !== ws) return;
+        cleanup();
+        resolve();
+      };
+
+      // Reject only when the socket is abandoned - either disconnect() set webSocket
+      // to null, or a new connect() call replaced it with a fresh socket instance.
+      // When ReconnectingWebSocket fires close as part of a reconnect cycle, this.webSocket
+      // is still the same ws reference, so we skip rejection and keep waiting for open.
+      const onClose = () => {
+        if (this.webSocket !== ws) {
+          cleanup();
+          reject(new Error("WebSocket connection closed before opening"));
+        }
+      };
+
+      ws.addEventListener("open", onOpen);
+      ws.addEventListener("close", onClose);
     });
   }
 
@@ -423,7 +480,12 @@ export class MailpitEvents {
    *   console.log("New message:", event.Data.Subject);
    * });
    *
-   * // Other code...
+   * // Ensure the socket is open before triggering any action that generates events.
+   * // onEvent() auto-connects, but the handshake is async - events broadcast before
+   * // the socket is open will be silently lost.
+   * await events.connect();
+   *
+   * // Other code that triggers events...
    *
    * // Unsubscribe listener when no longer needed
    * unsubscribe();
@@ -434,6 +496,8 @@ export class MailpitEvents {
    *   // Generic processing for all event types
    *   console.log(`Event ${event.Type} received`);
    * });
+   *
+   * await events.connect();
    *
    * // Other code...
    *
@@ -447,9 +511,10 @@ export class MailpitEvents {
   ): () => void {
     if (
       !this.webSocket ||
-      this.webSocket.readyState === ReconnectingWebSocket.CLOSED
+      this.webSocket.readyState === ReconnectingWebSocket.CLOSED ||
+      this.webSocket.readyState === ReconnectingWebSocket.CLOSING
     ) {
-      this.connect();
+      void this.connect().catch(() => {});
     }
 
     this.addListener(eventType, listener as (event: MailpitEvent) => void);
@@ -476,8 +541,13 @@ export class MailpitEvents {
    * @returns A promise that resolves with the event when received, or rejects on timeout
    * @example Basic usage
    * ```typescript
-   * // Create the promise before triggering the event
+   * // Register the listener first so no events are missed
    * const eventPromise = events.waitForEvent("new");
+   *
+   * // Ensure the socket is open before triggering the action.
+   * // waitForEvent() auto-connects, but the handshake is async - if you trigger
+   * // an action before the socket is open, the event may be broadcast and lost.
+   * await events.connect();
    *
    * // Do something that triggers an email to send
    * await mailpit.sendMessage({
@@ -496,17 +566,6 @@ export class MailpitEvents {
     eventType: T,
     timeout: number = 5_000,
   ): Promise<MailpitEventMap[T]> {
-    try {
-      if (
-        !this.webSocket ||
-        this.webSocket.readyState === ReconnectingWebSocket.CLOSED
-      ) {
-        this.connect();
-      }
-    } catch (error) {
-      return Promise.reject(error as Error);
-    }
-
     return new Promise((resolve, reject) => {
       let timer: ReturnType<typeof setTimeout> | null = null;
 
@@ -522,7 +581,30 @@ export class MailpitEvents {
         resolve(event as MailpitEventMap[T]);
       };
 
+      // Register listener BEFORE connecting so no event can be missed during
+      // the async handshake.
       this.addListener(eventType, listener);
+
+      // Auto-connect if needed
+      if (
+        !this.webSocket ||
+        this.webSocket.readyState === ReconnectingWebSocket.CLOSED ||
+        this.webSocket.readyState === ReconnectingWebSocket.CLOSING
+      ) {
+        let connectPromise: Promise<void>;
+        try {
+          connectPromise = this.connect();
+        } catch (error) {
+          cleanup();
+          reject(error instanceof Error ? error : new Error(String(error)));
+          return;
+        }
+        // Propagate connection errors into this promise
+        connectPromise.catch((error: unknown) => {
+          cleanup();
+          reject(error instanceof Error ? error : new Error(String(error)));
+        });
+      }
 
       if (isFinite(timeout)) {
         timer = setTimeout(() => {

--- a/packages/mailpit-ws/tests/index.spec.ts
+++ b/packages/mailpit-ws/tests/index.spec.ts
@@ -38,7 +38,7 @@ vi.mock("partysocket/ws", () => {
 describe("MailpitEvents", () => {
   let events: MailpitEvents;
   let internalEvents: {
-    connect: () => void;
+    connect: () => Promise<void>;
     disconnect: () => void;
     webSocket: ReconnectingWebSocket | null;
     onEvent: (
@@ -108,14 +108,149 @@ describe("MailpitEvents", () => {
     ).toBeNull();
   });
 
-  test("connect() should return early when already connected", () => {
+  test("connect() should return early when already connected", async () => {
     const existingWebSocket = {
       readyState: ReconnectingWebSocket.OPEN,
     } as unknown as ReconnectingWebSocket;
 
     internalEvents.webSocket = existingWebSocket;
-    internalEvents.connect();
+    await internalEvents.connect();
     expect(internalEvents.webSocket).toBe(existingWebSocket);
+  });
+
+  test("connect() should return a resolved Promise when socket is already open", async () => {
+    const existingWebSocket = {
+      readyState: ReconnectingWebSocket.OPEN,
+    } as unknown as ReconnectingWebSocket;
+
+    internalEvents.webSocket = existingWebSocket;
+    const result = internalEvents.connect();
+    expect(result).toBeInstanceOf(Promise);
+    await expect(result).resolves.toBeUndefined();
+  });
+
+  test("connect() should return a pending Promise that resolves when the socket opens", async () => {
+    // Mock a CONNECTING socket so connect() returns a pending Promise.
+    (ReconnectingWebSocket as unknown as Mock).mockImplementationOnce(function (
+      this: Record<string, unknown>,
+    ) {
+      this.readyState = ReconnectingWebSocket.CONNECTING;
+      this.addEventListener = vi.fn(
+        (event: string, handler: (...args: never[]) => void) => {
+          const handlers = mockWebSocketHandlers.get(event) ?? [];
+          handlers.push(handler);
+          mockWebSocketHandlers.set(event, handlers);
+        },
+      );
+      this.removeEventListener = vi.fn();
+      this.close = vi.fn();
+    });
+
+    const connectPromise = internalEvents.connect();
+    expect(connectPromise).toBeInstanceOf(Promise);
+
+    // Promise should still be pending before the open event fires.
+    let resolved = false;
+    void connectPromise.then(() => {
+      resolved = true;
+    });
+    await Promise.resolve();
+    expect(resolved).toBe(false);
+
+    // Fire the open event - all registered open handlers should run.
+    const openHandlers = mockWebSocketHandlers.get("open") ?? [];
+    expect(openHandlers.length).toBeGreaterThan(0);
+    openHandlers.forEach((h) => {
+      h({} as never);
+    });
+
+    await connectPromise;
+    expect(resolved).toBe(true);
+  });
+
+  test("connect() should create a new socket when existing socket is CLOSING", () => {
+    const closingWebSocket = {
+      readyState: ReconnectingWebSocket.CLOSING,
+    } as unknown as ReconnectingWebSocket;
+
+    internalEvents.webSocket = closingWebSocket;
+    void internalEvents.connect();
+    // A new socket should have been created to replace the CLOSING one
+    expect(internalEvents.webSocket).not.toBe(closingWebSocket);
+    expect(internalEvents.webSocket).not.toBeNull();
+  });
+
+  test("connect() should reject when disconnect() is called before the socket opens", async () => {
+    // Mock a CONNECTING socket so connect() returns a pending Promise.
+    (ReconnectingWebSocket as unknown as Mock).mockImplementationOnce(function (
+      this: Record<string, unknown>,
+    ) {
+      this.readyState = ReconnectingWebSocket.CONNECTING;
+      this.addEventListener = vi.fn(
+        (event: string, handler: (...args: never[]) => void) => {
+          const handlers = mockWebSocketHandlers.get(event) ?? [];
+          handlers.push(handler);
+          mockWebSocketHandlers.set(event, handlers);
+        },
+      );
+      this.removeEventListener = vi.fn();
+      this.close = vi.fn();
+    });
+
+    const connectPromise = internalEvents.connect();
+
+    // Simulate disconnect() - sets webSocket to null then fires close on the old socket
+    internalEvents.webSocket = null;
+    const closeHandlers = mockWebSocketHandlers.get("close") ?? [];
+    closeHandlers.forEach((h) => {
+      h({} as never);
+    });
+
+    await expect(connectPromise).rejects.toThrow(
+      "WebSocket connection closed before opening",
+    );
+  });
+
+  test("connect() should not reject when ReconnectingWebSocket fires close during a reconnect cycle", async () => {
+    // Mock a CONNECTING socket so connect() returns a pending Promise.
+    (ReconnectingWebSocket as unknown as Mock).mockImplementationOnce(function (
+      this: Record<string, unknown>,
+    ) {
+      this.readyState = ReconnectingWebSocket.CONNECTING;
+      this.addEventListener = vi.fn(
+        (event: string, handler: (...args: never[]) => void) => {
+          const handlers = mockWebSocketHandlers.get(event) ?? [];
+          handlers.push(handler);
+          mockWebSocketHandlers.set(event, handlers);
+        },
+      );
+      this.removeEventListener = vi.fn();
+      this.close = vi.fn();
+    });
+
+    const connectPromise = internalEvents.connect();
+
+    // Simulate a reconnect-cycle close (webSocket is still the same instance - NOT replaced)
+    const closeHandlers = mockWebSocketHandlers.get("close") ?? [];
+    closeHandlers.forEach((h) => {
+      h({} as never);
+    });
+
+    // Promise should still be pending - not rejected - because webSocket wasn't replaced
+    let rejected = false;
+    void connectPromise.catch(() => {
+      rejected = true;
+    });
+    await Promise.resolve();
+    expect(rejected).toBe(false);
+
+    // Now fire open - promise should resolve
+    const openHandlers = mockWebSocketHandlers.get("open") ?? [];
+    openHandlers.forEach((h) => {
+      h({} as never);
+    });
+    await connectPromise;
+    expect(rejected).toBe(false);
   });
 
   test("waitForEvent() should reject if connect() throws", async () => {
@@ -156,7 +291,7 @@ describe("MailpitEvents", () => {
   test("disconnect() should terminate the inner socket for clean process exit", () => {
     const mockTerminate = vi.fn();
 
-    internalEvents.connect();
+    void internalEvents.connect();
     expect(internalEvents.webSocket).not.toBeNull();
 
     const ws = internalEvents.webSocket as unknown as Record<string, unknown>;
@@ -171,7 +306,7 @@ describe("MailpitEvents", () => {
   test("connect() should unref the underlying socket and timers on open", () => {
     const mockUnref = vi.fn();
 
-    internalEvents.connect();
+    void internalEvents.connect();
 
     const openHandlers = mockWebSocketHandlers.get("open") ?? [];
     expect(openHandlers.length).toBeGreaterThan(0);

--- a/tests/e2e.spec.ts
+++ b/tests/e2e.spec.ts
@@ -1,6 +1,6 @@
 import * as fs from "fs";
 import path from "path";
-import { describe, test, expect, afterAll, afterEach } from "vitest";
+import { describe, test, expect, afterAll, afterEach, beforeAll } from "vitest";
 import {
   MailpitClient,
   type MailpitConfigurationResponse,
@@ -114,6 +114,11 @@ describe("Mailpit E2E Tests", () => {
   afterAll(async () => {
     events.disconnect();
     await mailpit.deleteMessages();
+  });
+
+  beforeAll(async () => {
+    // Ensure the WebSocket is connected before any test triggers events.
+    await events.connect();
   });
 
   test("sendMessage() should send message and trigger WebSocket events", async () => {


### PR DESCRIPTION
connect() now returns Promise<void> so callers can await the handshake. Listener registration is moved before auto-connect to eliminate the gap where an event could arrive before the listener was added.

Updates examples and docs to reflect explicit await events.connect() usage, including a Playwright fixture pattern.