### PR TITLE
fix(e2e): setReadStatus only triggers update event on change

### DIFF
--- a/tests/e2e.spec.ts
+++ b/tests/e2e.spec.ts
@@ -299,7 +299,7 @@ describe("Mailpit E2E Tests", () => {
 
       const response = await mailpit.setReadStatus({
         IDs: [messageId],
-        Read: true,
+        Read: false,
       });
       expect(response).toBe("ok");
 
@@ -309,7 +309,7 @@ describe("Mailpit E2E Tests", () => {
         Type: "update",
         Data: {
           ID: messageId,
-          Read: true,
+          Read: false,
         },
       });
 


### PR DESCRIPTION
Previously setReadStatus() would trigger a websocket update event if setReadStatus() was called against any message. As of Mailpit v3.0.0 the event will only trigger if the read status is changed.