### PR TITLE
fix: improve error handling messages in MailpitClient

### DIFF
--- a/packages/mailpit-api/src/index.ts
+++ b/packages/mailpit-api/src/index.ts
@@ -28,7 +28,7 @@ export interface MailpitClientOptions {
    * ```typescript
    * { fetchOptions: { headers: { Cookie: "session=abc123" } } }
    * ```
-   * @example Disabling TLS verification in Node.js (undici `Agent`)
+   * @example Disabling TLS verification in Node.js (undici Agent)
    * ```typescript
    * import { Agent } from "undici";
    * { fetchOptions: { dispatcher: new Agent({ connect: { rejectUnauthorized: false } }) } }
@@ -639,10 +639,12 @@ export class MailpitClient {
         headers: mergedHeaders,
         body: JSON.stringify(body),
       });
-    } catch (error: unknown) {
+    } catch (error) {
       // Per the Fetch spec, fetch() only throws TypeError (network or setup failures).
+      const reason = error instanceof Error ? error.message : String(error);
       throw new Error(
-        `Mailpit API Error: No response received from server at ${method} ${urlString}: ${(error as Error).message}`,
+        `Mailpit API Error: No response received from server at ${method} ${urlString}: ${reason}`,
+        { cause: error },
       );
     }
 
@@ -662,8 +664,12 @@ export class MailpitClient {
         return (await response.json()) as T;
       }
     } catch (error: unknown) {
+      const reason = error instanceof Error ? error.message : String(error);
       throw new Error(
-        `Mailpit API Error: ${(error as Error).toString()} at ${method} ${urlString}`,
+        `Mailpit API Error: ${reason} at ${method} ${urlString}`,
+        {
+          cause: error,
+        },
       );
     }
   }

--- a/packages/mailpit-api/tests/index.spec.ts
+++ b/packages/mailpit-api/tests/index.spec.ts
@@ -139,7 +139,7 @@ describe("MailpitClient", () => {
       headers: new Headers(),
     });
     await expect(client.getInfo()).rejects.toThrow(
-      "Mailpit API Error: SyntaxError: Unexpected token at GET http://localhost:8025/api/v1/info",
+      "Mailpit API Error: Unexpected token at GET http://localhost:8025/api/v1/info",
     );
   });
 


### PR DESCRIPTION
- Add cause to MailpitClient messages
- Change use of error.toString() to error.message